### PR TITLE
fix: example in README used FirstMigrationTrait instead of FirstMigration

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -97,7 +97,7 @@ fn main() {
     let uri = std::env::var("DATABASE_URL").unwrap();
     let pool = sqlx::Pool::<sqlx::Postgres>::connect(&uri).await.unwrap();
     let mut migrator = Migrator::new(&pool);
-    migrator.add_migration(Box::new(FirstMigrationTrait));
+    migrator.add_migration(Box::new(FirstMigration));
 }
 ```
 


### PR DESCRIPTION
Hi there! Thanks for this nice crate :)

I think I spotted a typo in one of the examples in the README (using `FirstMigrationTrait` which is not mentionned nor created anywhere before, instead of the struct `FirstMigration`).