### PR TITLE
fix: plan was not determined correctly for virtual migration

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -15,7 +15,7 @@ pub enum Error {
     #[error(transparent)]
     StdIo(#[from] std::io::Error),
     /// Error generated during planning state
-    #[error("planning error: {message}")]
+    #[error("plan error: {message}")]
     PlanError {
         /// Message for error
         message: String,


### PR DESCRIPTION
- fix: children parents where not determined correctly when virtual migration was used in replaces list
- fix: while generating migration list related to app name, migration name, related migration list where not correct if there is virtual migration in function call for run before or parent
- test: add tests for testing different virtual migration case instead of only testing non virtual migration
- test: not only test if plan is ok or err but also test plan have correct list and correct error