### PR TITLE
refactor: remove meaningless async_trait for Migration

### DIFF
--- a/examples/mysql/migrations/m0001_simple.rs
+++ b/examples/mysql/migrations/m0001_simple.rs
@@ -22,7 +22,6 @@ impl Operation<MySql> for M0001Operation {
 
 pub(crate) struct M0001Migration;
 
-#[async_trait::async_trait]
 impl Migration<MySql> for M0001Migration {
     fn app(&self) -> &'static str {
         "main"

--- a/examples/mysql/migrations/m0002_with_parents.rs
+++ b/examples/mysql/migrations/m0002_with_parents.rs
@@ -24,7 +24,6 @@ impl Operation<MySql> for M0002Operation {
 
 pub(crate) struct M0002Migration;
 
-#[async_trait::async_trait]
 impl Migration<MySql> for M0002Migration {
     fn app(&self) -> &'static str {
         "main"

--- a/examples/mysql/migrations/m0004_complex_operation.rs
+++ b/examples/mysql/migrations/m0004_complex_operation.rs
@@ -33,7 +33,6 @@ pub(crate) struct M0004Migration {
     pub(crate) message: String,
 }
 
-#[async_trait::async_trait]
 impl Migration<MySql> for M0004Migration {
     fn app(&self) -> &'static str {
         "main"

--- a/examples/mysql/migrations/m0005_reference_complex.rs
+++ b/examples/mysql/migrations/m0005_reference_complex.rs
@@ -24,7 +24,6 @@ impl Operation<MySql> for M0005Operation {
 
 pub(crate) struct M0005Migration;
 
-#[async_trait::async_trait]
 impl Migration<MySql> for M0005Migration {
     fn app(&self) -> &'static str {
         "main"

--- a/examples/postgres/migrations/m0001_simple.rs
+++ b/examples/postgres/migrations/m0001_simple.rs
@@ -22,7 +22,6 @@ impl Operation<Postgres> for M0001Operation {
 
 pub(crate) struct M0001Migration;
 
-#[async_trait::async_trait]
 impl Migration<Postgres> for M0001Migration {
     fn app(&self) -> &'static str {
         "main"

--- a/examples/postgres/migrations/m0002_with_parents.rs
+++ b/examples/postgres/migrations/m0002_with_parents.rs
@@ -24,7 +24,6 @@ impl Operation<Postgres> for M0002Operation {
 
 pub(crate) struct M0002Migration;
 
-#[async_trait::async_trait]
 impl Migration<Postgres> for M0002Migration {
     fn app(&self) -> &'static str {
         "main"

--- a/examples/postgres/migrations/m0004_complex_operation.rs
+++ b/examples/postgres/migrations/m0004_complex_operation.rs
@@ -33,7 +33,6 @@ pub(crate) struct M0004Migration {
     pub(crate) message: String,
 }
 
-#[async_trait::async_trait]
 impl Migration<Postgres> for M0004Migration {
     fn app(&self) -> &'static str {
         "main"

--- a/examples/postgres/migrations/m0005_reference_complex.rs
+++ b/examples/postgres/migrations/m0005_reference_complex.rs
@@ -24,7 +24,6 @@ impl Operation<Postgres> for M0005Operation {
 
 pub(crate) struct M0005Migration;
 
-#[async_trait::async_trait]
 impl Migration<Postgres> for M0005Migration {
     fn app(&self) -> &'static str {
         "main"

--- a/examples/sqlite/migrations/m0001_simple.rs
+++ b/examples/sqlite/migrations/m0001_simple.rs
@@ -22,7 +22,6 @@ impl Operation<Sqlite> for M0001Operation {
 
 pub(crate) struct M0001Migration;
 
-#[async_trait::async_trait]
 impl Migration<Sqlite> for M0001Migration {
     fn app(&self) -> &'static str {
         "main"

--- a/examples/sqlite/migrations/m0002_with_parents.rs
+++ b/examples/sqlite/migrations/m0002_with_parents.rs
@@ -24,7 +24,6 @@ impl Operation<Sqlite> for M0002Operation {
 
 pub(crate) struct M0002Migration;
 
-#[async_trait::async_trait]
 impl Migration<Sqlite> for M0002Migration {
     fn app(&self) -> &'static str {
         "main"

--- a/examples/sqlite/migrations/m0004_complex_operation.rs
+++ b/examples/sqlite/migrations/m0004_complex_operation.rs
@@ -33,7 +33,6 @@ pub(crate) struct M0004Migration {
     pub(crate) message: String,
 }
 
-#[async_trait::async_trait]
 impl Migration<Sqlite> for M0004Migration {
     fn app(&self) -> &'static str {
         "main"

--- a/examples/sqlite/migrations/m0005_reference_complex.rs
+++ b/examples/sqlite/migrations/m0005_reference_complex.rs
@@ -24,7 +24,6 @@ impl Operation<Sqlite> for M0005Operation {
 
 pub(crate) struct M0005Migration;
 
-#[async_trait::async_trait]
 impl Migration<Sqlite> for M0005Migration {
     fn app(&self) -> &'static str {
         "main"

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -24,7 +24,6 @@ macro_rules! migration {
     (
         $db:ty, $op:ty, $app_name:literal, $migration_name:literal, $parents:expr, $operations:expr
     ) => {
-        #[async_trait::async_trait]
         impl sqlx_migrator::migration::Migration<$db> for $op {
             fn app(&self) -> &str {
                 $app_name

--- a/src/migrator/tests.rs
+++ b/src/migrator/tests.rs
@@ -95,7 +95,6 @@ impl Migrate<Sqlite> for CustomMigrator {}
 
 macro_rules! migration {
     ($op:ty, $name:literal, $parents:expr, $replaces:expr, $run_before:expr) => {
-        #[async_trait::async_trait]
         impl crate::migration::Migration<sqlx::Sqlite> for $op {
             fn app(&self) -> &str {
                 "test"


### PR DESCRIPTION
There are no `async fn`s in `impl Migration`, so `#[async_trait]` is not needed.